### PR TITLE
2 debruinj indexing on abtsractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ node src/view/formatters.bs.js
 ```
 
 todo:
-* looks like an issue with debruinj conversions of statemetns with two abstractions, deferring to previous vars
 * modify identify laws to work over statements with abstractions
 * create a use case, to take a statement, generate all abstract variants, and generate all possible law matches for each variant
 * create "replace" capacity

--- a/src/entities/ast/debruinj.res
+++ b/src/entities/ast/debruinj.res
@@ -62,19 +62,24 @@ let getDebruinjIndices = node => {
 
   let rec getDebruinjIndices = (aggregate, node) =>
     switch node {
-    | BinaryOperation(_, _, lhs, rhs) => aggregate->getDebruinjIndices(lhs)->getDebruinjIndices(rhs)
-
+    | BinaryOperation(_, _, lhs, rhs) =>
+      aggregate
+      ->getDebruinjIndices(lhs)
+      ->getDebruinjIndices(rhs)
     | UnaryOperation(_, _, term) => getDebruinjIndices(aggregate, term)
     | Variable(_, name) => {
         let (indices, deferred) = aggregate
         (addSymbolToIndices(indices, name), deferred)
       }
-
     | Abstraction(_, symb, prop) => {
+        // with an abstaction we want to addTheSymbol to the indices, but not the sybols of the underlying
+        //  terms.  Otherswise the debruinj view of the abstract form isn't indexed properly if there happens to be
+        //  more than 1 abstraction.  we still want to collect those variables underlying the abstraction
+        //  so they are accounted for in use cases that might need them (e.g., cloning into a new alphabet, needs
+        //  to know all the current variables - even those hidden by abstraction)
         let (indices, deferred) = aggregate
         (addSymbolToIndices(indices, symb), defer(deferred, prop))
       }
-
     | Value(_, _) => aggregate
     }
 

--- a/src/entities/ast/debruinj.res
+++ b/src/entities/ast/debruinj.res
@@ -1,4 +1,4 @@
-open Ast;
+open Ast
 let increment = a => a + 1
 
 let max = (a, b) =>
@@ -10,61 +10,76 @@ let max = (a, b) =>
   | (None, None) => Some(-1)
   }
 
-
 let getNextDebuinjIndex = knownVariables =>
-    knownVariables
-    ->Belt.HashMap.String.keysToArray
-    ->Js.Array2.map(key => Belt.HashMap.String.get(knownVariables, key))
-    ->Js.Array2.reduce(max, Some(-1))
-    ->Belt.Option.getWithDefault(-1)
-    ->increment
-
+  knownVariables
+  ->Belt.HashMap.String.keysToArray
+  ->Js.Array2.map(key => Belt.HashMap.String.get(knownVariables, key))
+  ->Js.Array2.reduce(max, Some(-1))
+  ->Belt.Option.getWithDefault(-1)
+  ->increment
 
 let addSymbolToIndices = (indices, name) => {
-    let id = (_, x) => x
-    switch Belt.HashMap.String.has(indices, name) {
-    | true => indices
-    | false =>
-        getNextDebuinjIndex(indices)
-        -> Belt.HashMap.String.set(indices, name, _)
-        -> id(indices)
-    }
+  let id = (_, x) => x
+  switch Belt.HashMap.String.has(indices, name) {
+  | true => indices
+  | false => getNextDebuinjIndex(indices)->Belt.HashMap.String.set(indices, name, _)->id(indices)
+  }
 }
 
-let getNextSymbol = (indices) => {
-    let max = (a, b) => switch (a > b) {
+let getNextSymbol = indices => {
+  let max = (a, b) =>
+    switch a > b {
     | true => a
     | false => b
     }
 
-    let increment = x => Belt.Float.toInt(x) + 1
+  let increment = x => Belt.Float.toInt(x) + 1
 
-    indices
-    -> Belt.HashMap.String.keysToArray
-    -> Belt.Array.reduce("", max)
-    -> Js.String2.charCodeAt(0)
-    -> increment
-    -> Js.String2.fromCharCode
+  indices
+  ->Belt.HashMap.String.keysToArray
+  ->Belt.Array.reduce("", max)
+  ->Js.String2.charCodeAt(0)
+  ->increment
+  ->Js.String2.fromCharCode
 }
 
 let getDebruinjIndices = node => {
+  let addDeferredVariables = (indices, name) => {
+    addSymbolToIndices(indices, name)
+}
 
- let rec getDebruinjIndices = (indices, node) =>
+  let rec defer = (deferred, node) =>
     switch node {
-    | BinaryOperation(_, _, lhs, rhs) => {
-        indices
-        ->getDebruinjIndices(lhs)
-        ->getDebruinjIndices(rhs)
-    }
-    | UnaryOperation(_, _, term) => getDebruinjIndices(indices, term)
-    | Variable(_, name) => addSymbolToIndices(indices, name)
-    | Abstraction(_, symb, prop) =>
-        indices
-        ->addSymbolToIndices(symb)
-        ->getDebruinjIndices(prop)
-    | Value(_, _) => indices
+    | BinaryOperation(_, _, lhs, rhs) => defer(deferred, lhs)->defer(rhs)
+    | UnaryOperation(_, _, term) => defer(deferred, term)
+    | Variable(_, name) => {
+        Belt.Array.push(deferred, name)
+        deferred
+      }
+    | Abstraction(_, _, prop) => defer(deferred, prop)
+    | Value(_, _) => deferred
     }
 
-  Belt.HashMap.String.make(~hintSize=10)
-  ->getDebruinjIndices(node)
+  let rec getDebruinjIndices = (aggregate, node) =>
+    switch node {
+    | BinaryOperation(_, _, lhs, rhs) => aggregate->getDebruinjIndices(lhs)->getDebruinjIndices(rhs)
+
+    | UnaryOperation(_, _, term) => getDebruinjIndices(aggregate, term)
+    | Variable(_, name) => {
+        let (indices, deferred) = aggregate
+        (addSymbolToIndices(indices, name), deferred)
+      }
+
+    | Abstraction(_, symb, prop) => {
+        let (indices, deferred) = aggregate
+        (addSymbolToIndices(indices, symb), defer(deferred, prop))
+      }
+
+    | Value(_, _) => aggregate
+    }
+
+  let initial = (Belt.HashMap.String.make(~hintSize=10), [])
+  let (indices, deferred) = getDebruinjIndices(initial, node)
+  let allIndices = Belt.Array.reduce(deferred, indices, addDeferredVariables)
+  allIndices
 }

--- a/src/main.res
+++ b/src/main.res
@@ -33,9 +33,9 @@ let printLawsFor = str => {
 
 
 //let x = Parser.parse("a and b or c and not(a or b) and not(a or c) and not(c) and (a or b)")
-let x = Parser.parse("not(a and b) and not(b or c)")
-//let x = Parser.parse("a and not(b)")
-//let y = Parser.parse("a and b")
+//let x = Parser.parse("not(a and b) and not(b or c)")
+let x = Parser.parse("a and not(b) or (c and not(b))")
+//let x = Parser.parse("a and b")
 
 
 let xs = Abstraction.getAbstractions(x)


### PR DESCRIPTION
fixed:

```
original: ((a ∧ ¬(b)) ∨ (c ∧ ¬(b))) is expressed as ((0 ∧ ¬(1)) ∨ (2 ∧ ¬(1)))
Variation 1: ((a ∧ [d/¬(b)]) ∨ (c ∧ [d/¬(b)])) is expressed as ((0 ∧ [1/¬(3)]) ∨ (2 ∧ [1/¬(3)]))
Variation 2: ([e/(a ∧ ¬(b))] ∨ (c ∧ [d/¬(b)])) is expressed as ([0/(3 ∧ ¬(4))] ∨ (1 ∧ [2/¬(4)]))
Variation 3: ([e/(a ∧ ¬(b))] ∨ [f/(c ∧ ¬(b))]) is expressed as ([0/(2 ∧ ¬(3))] ∨ [1/(4 ∧ ¬(3))])
Variation 4: [g/((a ∧ ¬(b)) ∨ (c ∧ ¬(b)))] is expressed as [0/((1 ∧ ¬(2)) ∨ (3 ∧ ¬(2)))]
```

- Variation 1: `not(b)` is replaced in both places as the `Abstraction(d)` and corresponding Debruinj indedx `Abstraction(1)` the variable `b` under the abstraction is given a later index of `3` on deferral.
- Variation 2: `(a ∧ ¬(b))` is replaced with the `Abtraction(e)` aka `Abstraction(0)` the next variable, `Variable(c)` not hidden under `Abstraction(e)` correctly has the index 1, followed by `Variable(2)` having index 2.  `Vairable(a)` and `Variable(b)` are both hidden under abstractions and you can see their indexes come in as 3 & 4 correspondingly.

Index orders are important to be able to apply laws. THe laws are matched based on the order of introduction of variables, and in their application they are not applied underneath abstractions. e.g. `(a and not(c or b))` could commute at `c or b` and at `a and not(...)` without deferring the indexes of `c` and `b` the latter would not match the commutative patter `p and q = q and p`, since the staement would trasnalte to `0 and [3/not(1 or 2)]` and which ouldn't match the law `0 and 1 = 1 and 0`